### PR TITLE
Disable Hibernate DDL auto and migrate to UUID for user IDs                                 

### DIFF
--- a/src/main/java/com/group3/backend/entity/Feedback.java
+++ b/src/main/java/com/group3/backend/entity/Feedback.java
@@ -34,11 +34,11 @@ public class Feedback {
         this.submissionId = submissionId;
     }
 
-    public Long getUserId() {
+    public UUID getUserId() {
         return userId;
     }
 
-    public void setUserId(Long userId) {
+    public void setUserId(UUID userId) {
         this.userId = userId;
     }
 

--- a/src/main/java/com/group3/backend/entity/Feedback.java
+++ b/src/main/java/com/group3/backend/entity/Feedback.java
@@ -1,6 +1,7 @@
 package com.group3.backend.entity;
 import java.time.LocalDateTime;
 import jakarta.persistence.*;
+import java.util.UUID;                                                                             
 
 @Entity
 public class Feedback {
@@ -10,7 +11,7 @@ public class Feedback {
     private Long id;
 
     private Long submissionId;
-    private Long userId;
+    private UUID userId;
 
     @Column(columnDefinition = "TEXT")
     private String feedbackText;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,4 +3,4 @@ spring.datasource.url=jdbc:postgresql://db.ditrpxtnudjmjfobiaul.supabase.co:5432
 spring.datasource.username=postgres
 spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=none

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 spring.application.name=backend
+spring.profiles.active=local
 spring.datasource.url=jdbc:postgresql://db.ditrpxtnudjmjfobiaul.supabase.co:5432/postgres?connectTimeout=5
 spring.datasource.username=postgres
-spring.datasource.password=
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
  ## Summary
  - Disabled Hibernate's auto DDL (data definition language) generation by setting spring.jpa.hibernate.ddl-auto=none           
  - Changed Feedback.userId from Long to UUID to match Supabase auth system                          
  - Updated corresponding getters/setters to use UUID type                                           
  - Database schema is now manually managed in Supabase with RLS policies           
  - Changed Active spring profile  to local               
                                                                                                     
  ## Why                                                                                                
                                                                                                     
  Hibernate's auto DDL (update mode) is unreliable on remote databases like Supabase. It can timeout 
  during schema introspection or fail due to RLS policies. Managing the schema manually gives us     
  better control and stability.                                                                      
                                                                                                     
  Additionally, Supabase's authentication system uses UUIDs for user IDs, so storing user_id as a    
  Long was incompatible with the RLS policies that compare against auth.uid().                       
                                                                                                     
  ## Changes                                                                                            
   
  - application.properties: 
    - Changed ddl-auto from update to none, 
    - Made active profile local
    - removed deprecated PostgreSQLDialect line                             
  - Feedback.java:
    - Added import java.util.UUID                                                                    
    - Changed userId field type from Long to UUID
    - Updated getUserId() return type to UUID                                                        
    - Updated setUserId() parameter type to UUID                                                     
   
  ## Database Schema                                                                                    
                  
  The feedback table in Supabase has been manually created with:                                     
  - user_id as UUID type
  - Row Level Security enabled                                                                       
  - Policies restricting users to their own feedback

  ## SQL Used

   DROP TABLE feedback;                                                                               
                  
  CREATE TABLE feedback (                                                                            
    id BIGSERIAL PRIMARY KEY,
    submission_id BIGINT,                                                                            
    user_id UUID,  -- Changed from BIGINT to UUID
    feedback_text TEXT,
    score INTEGER,
    created_at TIMESTAMP DEFAULT NOW()
  );                                                                                                 
   
  ALTER TABLE feedback ENABLE ROW LEVEL SECURITY;                                                    
                  
  CREATE POLICY "Users can view their own feedback" ON feedback
    FOR SELECT USING (auth.uid() = user_id);

  CREATE POLICY "Users can insert their own feedback" ON feedback                                    
    FOR INSERT WITH CHECK (auth.uid() = user_id);

   CREATE POLICY "Admins can do anything" ON feedback                                                 
    FOR ALL USING (
      (SELECT role FROM auth.users WHERE id = auth.uid()) = 'admin'                                  
    );        