### PR TITLE
feat(submissions): GET/PUT by id + Gemini re-review for edits

### DIFF
--- a/src/main/java/com/group3/backend/controller/SubmissionController.java
+++ b/src/main/java/com/group3/backend/controller/SubmissionController.java
@@ -1,6 +1,7 @@
 package com.group3.backend.controller;
 
 import com.group3.backend.dto.SubmissionRequest;
+import com.group3.backend.dto.SubmissionUpdateRequest;
 import com.group3.backend.entity.Problem;
 import com.group3.backend.repository.FeedbackRepository;
 
@@ -10,15 +11,21 @@ import com.group3.backend.repository.ProblemRepository;
 import com.group3.backend.repository.SubmissionRepository;
 import com.group3.backend.service.GeminiReviewService;
 import com.group3.backend.service.GeminiReviewService.ReviewResult;
+import com.group3.backend.service.SupabaseTokenService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/submissions")
+@CrossOrigin
 public class SubmissionController {
 
     @Autowired
@@ -32,6 +39,9 @@ public class SubmissionController {
 
     @Autowired
     private GeminiReviewService geminiReviewService;
+
+    @Autowired
+    private SupabaseTokenService tokenService;
 
     @PostMapping
     public Submission createSubmission(@RequestBody SubmissionRequest request) {
@@ -66,6 +76,92 @@ public class SubmissionController {
         feedbackRepository.save(feedback);
 
         return savedSubmission;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Submission> getSubmission(
+            @PathVariable Long id,
+            @RequestHeader(value = "Authorization", required = false) String authHeader) {
+        Optional<UUID> userId = resolveUserIdFromAuth(authHeader);
+        if (userId.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        return submissionRepository.findById(id)
+                .filter(sub -> userId.get().equals(sub.getUserId()))
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Submission> updateSubmission(
+            @PathVariable Long id,
+            @RequestBody SubmissionUpdateRequest body,
+            @RequestHeader(value = "Authorization", required = false) String authHeader) {
+        Optional<UUID> userId = resolveUserIdFromAuth(authHeader);
+        if (userId.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        if (body.getCode() == null || body.getCode().trim().length() < 10) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        Optional<Submission> opt = submissionRepository.findById(id);
+        if (opt.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Submission submission = opt.get();
+        if (!userId.get().equals(submission.getUserId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        String language = normalizeLanguage(body.getLanguage());
+        submission.setCode(body.getCode());
+        if (body.getTimeTaken() != null) {
+            submission.setTimeTaken(body.getTimeTaken());
+        }
+
+        Problem problem = problemRepository.findById(submission.getProblemId()).orElse(null);
+        ReviewResult review = geminiReviewService.reviewSubmission(problem, submission.getCode(), language);
+        submission.setStatus(review.status());
+
+        Submission saved = submissionRepository.save(submission);
+
+        Feedback feedback = feedbackRepository.findBySubmissionId(saved.getId())
+                .orElseGet(() -> {
+                    Feedback fb = new Feedback();
+                    fb.setSubmissionId(saved.getId());
+                    fb.setUserId(userId.get());
+                    return fb;
+                });
+        feedback.setUserId(userId.get());
+        feedback.setFeedbackText(review.feedbackText());
+        feedback.setScore(review.score());
+        feedback.setCreatedAt(LocalDateTime.now());
+        feedbackRepository.save(feedback);
+
+        return ResponseEntity.ok(saved);
+    }
+
+    private Optional<UUID> resolveUserIdFromAuth(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return Optional.empty();
+        }
+        String token = authHeader.substring("Bearer ".length());
+        Map<String, Object> claims = tokenService.validateToken(token);
+        if (claims == null) {
+            return Optional.empty();
+        }
+        Object sub = claims.get("sub");
+        if (sub == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(UUID.fromString(sub.toString()));
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
     }
 
     private String normalizeLanguage(String language) {

--- a/src/main/java/com/group3/backend/dto/SubmissionUpdateRequest.java
+++ b/src/main/java/com/group3/backend/dto/SubmissionUpdateRequest.java
@@ -1,0 +1,32 @@
+package com.group3.backend.dto;
+
+/** Update an existing submission code and optionally re-run Gemini review. */
+public class SubmissionUpdateRequest {
+    private String code;
+    private String language = "python";
+    private Integer timeTaken;
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public Integer getTimeTaken() {
+        return timeTaken;
+    }
+
+    public void setTimeTaken(Integer timeTaken) {
+        this.timeTaken = timeTaken;
+    }
+}


### PR DESCRIPTION
## Summary
Implements authenticated load and update of a submission so the mobile review screen can show saved code and re-run Gemini after edits.

## Changes
- `SubmissionUpdateRequest`: `code`, `language`, optional `timeTaken`
- **GET** `/api/submissions/{id}`: requires valid Supabase Bearer; returns submission only when `sub` matches submission owner
- **PUT** `/api/submissions/{id}`: updates code, re-runs `GeminiReviewService`, upserts `Feedback`
- `@CrossOrigin` on controller

## Tracking
Related to https://github.com/CST438-Project3-Group3-LeetCodeReviewer/frontend/issues/39

Merge **before or with** the frontend PR that consumes these endpoints.

Made with [Cursor](https://cursor.com)